### PR TITLE
Removed the use of the UserInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ TODO
 
 Please, do not hesitate to [report bugs](https://github.com/dmishh/SettingsBundle/issues) or send [pull requests](https://github.com/dmishh/SettingsBundle/pulls). It will help to motivate me to support library better than anything else :)
 
+#### Version 2.0.0-dev
+
+Make sure to read the [Upgrade.md](Upgrade.md) to successfully migrate your application.
+
+* New interface for your entity. We are no longer using `UserInterface`. Use `SettingOwner` instead. 
+
 #### Version 1.0.2-1.0.6
 * Minor code improvements and bug fixes
 * System messages translations to en, it, es, fr, de, ru, uk, sv languages

--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ Bundle is used for storing configuration with Symfony2 in database using Doctrin
 
     // Each of methods above has last optional $user parameter
     // that allows to get/set per-user settings
-    // $user parameter implements UserInterface from Symfony Security Component
-    // Your User Entity must implement UserInterface if you wish to use per-user settings
+    // Your User Entity must implement SettingOwner if you wish to use per-user settings
 
     // These are same examples as above with only difference that they are for current user
     $this->get('settings_manager')->set('my_first_setting', 'user_value', $this->getUser());

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,0 +1,42 @@
+# Upgrade
+
+## Upgrade from 1.0.x to 2.0.0
+
+Your User entity should implement the `Dmishh\Bundle\SettingsBundle\Entity\SettingOwner` interface. In order to maintain
+your user setting you need to implement the `getSettingIdentifier` to return the username.
+
+``` php
+class MyUser implements SettingOwner
+{
+  // ..
+
+  public function getSettingIdentifier()
+  {
+    return $this->getUsername();
+  }
+}
+```
+
+You do also need to update your database tables.
+
+**1) Via [DoctrineMigrationsBundle](http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html):**
+
+```bash
+php app/console doctrine:migrations:diff
+php app/console doctrine:migrations:migrate
+```
+
+**2) Manually:**
+
+```bash
+php app/console doctrine:schema:update --force
+```
+
+**3) Queries:**
+
+The following queries should be executed:
+``` sql
+DROP INDEX name_user_name_idx ON dmishh_settings;
+ALTER TABLE dmishh_settings CHANGE username ownerId VARCHAR(255) DEFAULT NULL;
+CREATE INDEX name_owner_id_idx ON dmishh_settings (name, ownerId);
+```

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
@@ -11,10 +11,10 @@
 
 namespace Dmishh\Bundle\SettingsBundle\Controller;
 
+use Dmishh\Bundle\SettingsBundle\Entity\SettingOwner;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 class SettingsController extends Controller
 {
@@ -49,15 +49,22 @@ class SettingsController extends Controller
             throw new AccessDeniedException($this->get('translator')->trans('not_allowed_to_edit_own_settings', array(), 'settings'));
         }
 
-        return $this->manage($request, $this->get('security.context')->getToken()->getUser());
+        $user = $this->get('security.context')->getToken()->getUser();
+
+        if (!($user instanceof SettingOwner)) {
+            //For this to work the User entity must implement SettingOwner
+            throw new AccessDeniedException();
+        }
+
+        return $this->manage($request, $user);
     }
 
     /**
      * @param Request $request
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function manage(Request $request, UserInterface $user = null)
+    protected function manage(Request $request, SettingOwner $user = null)
     {
         $form = $this->createForm('settings_management', $this->get('settings_manager')->all($user));
 

--- a/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
@@ -61,19 +61,20 @@ class SettingsController extends Controller
 
     /**
      * @param Request $request
-     * @param SettingOwner|null $user
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @param SettingOwner|null $owner
+     *
+*@return \Symfony\Component\HttpFoundation\Response
      */
-    protected function manage(Request $request, SettingOwner $user = null)
+    protected function manage(Request $request, SettingOwner $owner = null)
     {
-        $form = $this->createForm('settings_management', $this->get('settings_manager')->all($user));
+        $form = $this->createForm('settings_management', $this->get('settings_manager')->all($owner));
 
         if ($request->isMethod('post')) {
             $form->handleRequest($request);
 
             if ($form->isValid()) {
 
-                $this->get('settings_manager')->setMany($form->getData(), $user);
+                $this->get('settings_manager')->setMany($form->getData(), $owner);
                 $this->get('session')->getFlashBag()->add('success', $this->get('translator')->trans('settings_updated', array(), 'settings'));
 
                 return $this->redirect($request->getUri());

--- a/src/Dmishh/Bundle/SettingsBundle/Entity/Setting.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Entity/Setting.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(
  *  name="dmishh_settings",
- *  indexes={@ORM\Index(name="name_user_name_idx", columns={"name", "username"})}
+ *  indexes={@ORM\Index(name="name_owner_id_idx", columns={"name", "ownerId"})}
  * )
  * @ORM\Entity
  */
@@ -52,7 +52,7 @@ class Setting
      *
      * @ORM\Column(type="string", length=255, nullable=true)
      */
-    private $username;
+    private $ownerId;
 
     /**
      * Get id
@@ -113,19 +113,19 @@ class Setting
     /**
      * @return string
      */
-    public function getUsername()
+    public function getOwnerId()
     {
-        return $this->username;
+        return $this->ownerId;
     }
 
     /**
-     * @param string $username
+     * @param string $ownerId
      *
      * @return Setting
      */
-    public function setUsername($username)
+    public function setOwnerId($ownerId)
     {
-        $this->username = $username;
+        $this->ownerId = $ownerId;
 
         return $this;
     }

--- a/src/Dmishh/Bundle/SettingsBundle/Entity/SettingOwner.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Entity/SettingOwner.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Dmishh\Bundle\SettingsBundle\Entity;
+
+/**
+ * This interface must be implemented by the Entity connected to a setting
+ */
+interface SettingOwner
+{
+    public function getUsername();
+} 

--- a/src/Dmishh/Bundle/SettingsBundle/Entity/SettingOwner.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Entity/SettingOwner.php
@@ -7,5 +7,5 @@ namespace Dmishh\Bundle\SettingsBundle\Entity;
  */
 interface SettingOwner
 {
-    public function getUsername();
+    public function getSettingIdentifier();
 } 

--- a/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
@@ -12,12 +12,12 @@
 namespace Dmishh\Bundle\SettingsBundle\Manager;
 
 use Dmishh\Bundle\SettingsBundle\Entity\Setting;
+use Dmishh\Bundle\SettingsBundle\Entity\SettingOwner;
 use Dmishh\Bundle\SettingsBundle\Exception\UnknownSettingException;
 use Dmishh\Bundle\SettingsBundle\Exception\WrongScopeException;
 use Dmishh\Bundle\SettingsBundle\Serializer\SerializerFactory;
 use Dmishh\Bundle\SettingsBundle\Serializer\SerializerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Settings Manager provides settings management and persistence using Doctrine's Object Manager
@@ -73,7 +73,7 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function get($name, UserInterface $user = null)
+    public function get($name, SettingOwner $user = null)
     {
         $this->validateSetting($name, $user);
         $this->loadSettings($user);
@@ -94,7 +94,7 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function all(UserInterface $user = null)
+    public function all(SettingOwner $user = null)
     {
         $this->loadSettings($user);
 
@@ -108,7 +108,7 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function set($name, $value, UserInterface $user = null)
+    public function set($name, $value, SettingOwner $user = null)
     {
         $this->setWithoutFlush($name, $value, $user);
 
@@ -118,7 +118,7 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function setMany(array $settings, UserInterface $user = null)
+    public function setMany(array $settings, SettingOwner $user = null)
     {
         foreach ($settings as $name => $value) {
             $this->setWithoutFlush($name, $value, $user);
@@ -130,7 +130,7 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function clear($name, UserInterface $user = null)
+    public function clear($name, SettingOwner $user = null)
     {
         return $this->set($name, null, $user);
     }
@@ -140,10 +140,10 @@ class SettingsManager implements SettingsManagerInterface
      *
      * @param string $name
      * @param mixed $value
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return SettingsManager
      */
-    private function setWithoutFlush($name, $value, UserInterface $user = null)
+    private function setWithoutFlush($name, $value, SettingOwner $user = null)
     {
         $this->validateSetting($name, $user);
         $this->loadSettings($user);
@@ -161,11 +161,11 @@ class SettingsManager implements SettingsManagerInterface
      * Flushes settings defined by $names to database
      *
      * @param string|array $names
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @throws \Dmishh\Bundle\SettingsBundle\Exception\UnknownSerializerException
      * @return SettingsManager
      */
-    private function flush($names, UserInterface $user = null)
+    private function flush($names, SettingOwner $user = null)
     {
         $names = (array)$names;
 
@@ -213,12 +213,12 @@ class SettingsManager implements SettingsManagerInterface
      * Checks that $name is valid setting and it's scope is also valid
      *
      * @param string $name
-     * @param UserInterface $user
+     * @param SettingOwner $user
      * @return SettingsManager
      * @throws \Dmishh\Bundle\SettingsBundle\Exception\UnknownSettingException
      * @throws \Dmishh\Bundle\SettingsBundle\Exception\WrongScopeException
      */
-    private function validateSetting($name, UserInterface $user = null)
+    private function validateSetting($name, SettingOwner $user = null)
     {
         // Name validation
         if (!is_string($name) || !array_key_exists($name, $this->settingsConfiguration)) {
@@ -239,10 +239,10 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * Settings lazy loading
      *
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return SettingsManager
      */
-    private function loadSettings(UserInterface $user = null)
+    private function loadSettings(SettingOwner $user = null)
     {
         // Global settings
         if ($this->globalSettings === null) {
@@ -260,11 +260,11 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * Retreives settings from repository
      *
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @throws \Dmishh\Bundle\SettingsBundle\Exception\UnknownSerializerException
      * @return array
      */
-    private function getSettingsFromRepository(UserInterface $user = null)
+    private function getSettingsFromRepository(SettingOwner $user = null)
     {
         $settings = array();
 

--- a/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
@@ -83,8 +83,8 @@ class SettingsManager implements SettingsManagerInterface
         if ($user === null) {
             $value = $this->globalSettings[$name];
         } else {
-            if ($this->userSettings[$user->getUsername()][$name] !== null) {
-                $value = $this->userSettings[$user->getUsername()][$name];
+            if ($this->userSettings[$user->getSettingIdentifier()][$name] !== null) {
+                $value = $this->userSettings[$user->getSettingIdentifier()][$name];
             }
         }
 
@@ -101,7 +101,7 @@ class SettingsManager implements SettingsManagerInterface
         if ($user === null) {
             return $this->globalSettings;
         } else {
-            return $this->userSettings[$user->getUsername()];
+            return $this->userSettings[$user->getSettingIdentifier()];
         }
     }
 
@@ -151,7 +151,7 @@ class SettingsManager implements SettingsManagerInterface
         if ($user === null) {
             $this->globalSettings[$name] = $value;
         } else {
-            $this->userSettings[$user->getUsername()][$name] = $value;
+            $this->userSettings[$user->getSettingIdentifier()][$name] = $value;
         }
 
         return $this;
@@ -169,7 +169,7 @@ class SettingsManager implements SettingsManagerInterface
     {
         $names = (array)$names;
 
-        $settings = $this->repository->findBy(array('name' => $names, 'username' => $user === null ? null : $user->getUsername()));
+        $settings = $this->repository->findBy(array('name' => $names, 'ownerId' => $user === null ? null : $user->getSettingIdentifier()));
         $findByName = function ($name) use ($settings) {
             $setting = array_filter(
                 $settings,
@@ -196,7 +196,7 @@ class SettingsManager implements SettingsManagerInterface
                 $setting = new Setting();
                 $setting->setName($name);
                 if ($user !== null) {
-                    $setting->setUsername($user->getUsername());
+                    $setting->setOwnerId($user->getSettingIdentifier());
                 }
                 $this->em->persist($setting);
             }
@@ -250,8 +250,8 @@ class SettingsManager implements SettingsManagerInterface
         }
 
         // User settings
-        if ($user !== null && ($this->userSettings === null || !array_key_exists($user->getUsername(), $this->userSettings))) {
-            $this->userSettings[$user->getUsername()] = $this->getSettingsFromRepository($user);
+        if ($user !== null && ($this->userSettings === null || !array_key_exists($user->getSettingIdentifier(), $this->userSettings))) {
+            $this->userSettings[$user->getSettingIdentifier()] = $this->getSettingsFromRepository($user);
         }
 
         return $this;
@@ -278,7 +278,7 @@ class SettingsManager implements SettingsManagerInterface
         }
 
         /** @var Setting $setting */
-        foreach ($this->repository->findBy(array('username' => $user === null ? null : $user->getUsername())) as $setting) {
+        foreach ($this->repository->findBy(array('ownerId' => $user === null ? null : $user->getSettingIdentifier())) as $setting) {
             if (array_key_exists($setting->getName(), $settings)) {
                 $settings[$setting->getName()] = $this->serializer->unserialize($setting->getValue());
             }

--- a/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManagerInterface.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManagerInterface.php
@@ -11,7 +11,7 @@
 
 namespace Dmishh\Bundle\SettingsBundle\Manager;
 
-use Symfony\Component\Security\Core\User\UserInterface;
+use Dmishh\Bundle\SettingsBundle\Entity\SettingOwner;
 
 interface SettingsManagerInterface
 {
@@ -23,44 +23,44 @@ interface SettingsManagerInterface
      * Returns setting value by its name
      *
      * @param string $name
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return mixed
      */
-    function get($name, UserInterface $user = null);
+    function get($name, SettingOwner $user = null);
 
     /**
      * Returns all settings as associative name-value array
      *
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return array
      */
-    function all(UserInterface $user = null);
+    function all(SettingOwner $user = null);
 
     /**
      * Sets setting value by its name
      *
      * @param string $name
      * @param mixed $value
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return SettingsManagerInterface
      */
-    function set($name, $value, UserInterface $user = null);
+    function set($name, $value, SettingOwner $user = null);
 
     /**
      * Sets settings' values from associative name-value array
      *
      * @param array $settings
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return SettingsManagerInterface
      */
-    function setMany(array $settings, UserInterface $user = null);
+    function setMany(array $settings, SettingOwner $user = null);
 
     /**
      * Clears setting value
      *
      * @param string $name
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return SettingsManagerInterface
      */
-    function clear($name, UserInterface $user = null);
+    function clear($name, SettingOwner $user = null);
 }

--- a/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManagerInterface.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManagerInterface.php
@@ -23,44 +23,49 @@ interface SettingsManagerInterface
      * Returns setting value by its name
      *
      * @param string $name
-     * @param SettingOwner|null $user
-     * @return mixed
+     * @param SettingOwner|null $owner
+     *
+*@return mixed
      */
-    function get($name, SettingOwner $user = null);
+    function get($name, SettingOwner $owner = null);
 
     /**
      * Returns all settings as associative name-value array
      *
-     * @param SettingOwner|null $user
-     * @return array
+     * @param SettingOwner|null $owner
+     *
+*@return array
      */
-    function all(SettingOwner $user = null);
+    function all(SettingOwner $owner = null);
 
     /**
      * Sets setting value by its name
      *
      * @param string $name
      * @param mixed $value
-     * @param SettingOwner|null $user
-     * @return SettingsManagerInterface
+     * @param SettingOwner|null $owner
+     *
+*@return SettingsManagerInterface
      */
-    function set($name, $value, SettingOwner $user = null);
+    function set($name, $value, SettingOwner $owner = null);
 
     /**
      * Sets settings' values from associative name-value array
      *
      * @param array $settings
-     * @param SettingOwner|null $user
-     * @return SettingsManagerInterface
+     * @param SettingOwner|null $owner
+     *
+*@return SettingsManagerInterface
      */
-    function setMany(array $settings, SettingOwner $user = null);
+    function setMany(array $settings, SettingOwner $owner = null);
 
     /**
      * Clears setting value
      *
      * @param string $name
-     * @param SettingOwner|null $user
-     * @return SettingsManagerInterface
+     * @param SettingOwner|null $owner
+     *
+*@return SettingsManagerInterface
      */
-    function clear($name, SettingOwner $user = null);
+    function clear($name, SettingOwner $owner = null);
 }

--- a/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
@@ -197,12 +197,13 @@ class SettingsManagerTest extends AbstractTest
     }
 
     /**
-     * @param string $username
-     * @return \Dmishh\Bundle\SettingsBundle\Entity\SettingOwner
+     * @param string $ownerId
+     *
+*@return \Dmishh\Bundle\SettingsBundle\Entity\SettingOwner
      */
-    protected function createUser($username = 'user1')
+    protected function createUser($ownerId = 'user1')
     {
-        return Mockery::mock('Dmishh\Bundle\SettingsBundle\Entity\SettingOwner', array('getUsername' => $username));
+        return Mockery::mock('Dmishh\Bundle\SettingsBundle\Entity\SettingOwner', array('getSettingIdentifier' => $ownerId));
     }
 
     protected function createSettingsManager(array $configuration = array(), $serialization = 'php')

--- a/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
@@ -44,52 +44,52 @@ class SettingsManagerTest extends AbstractTest
 
     public function testUserSettingsAccessor()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
-        $settingsManager->set('some_setting', 'VALUE_USER', $user);
-        $this->assertEquals('VALUE_USER', $settingsManager->get('some_setting', $user));
+        $settingsManager->set('some_setting', 'VALUE_USER', $owner);
+        $this->assertEquals('VALUE_USER', $settingsManager->get('some_setting', $owner));
     }
 
     public function testUserSettingsClear()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
-        $settingsManager->set('some_setting', 'VALUE_GLOBAL', $user);
-        $settingsManager->clear('some_setting', $user);
-        $this->assertNull($settingsManager->get('some_setting', $user));
+        $settingsManager->set('some_setting', 'VALUE_GLOBAL', $owner);
+        $settingsManager->clear('some_setting', $owner);
+        $this->assertNull($settingsManager->get('some_setting', $owner));
     }
 
     public function testGlobalAndUserSettingsArentIntersect()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
         $settingsManager->set('some_setting', 'VALUE_GLOBAL');
-        $settingsManager->set('some_setting', 'VALUE_USER', $user);
+        $settingsManager->set('some_setting', 'VALUE_USER', $owner);
         $this->assertEquals('VALUE_GLOBAL', $settingsManager->get('some_setting'));
-        $this->assertEquals('VALUE_USER', $settingsManager->get('some_setting', $user));
+        $this->assertEquals('VALUE_USER', $settingsManager->get('some_setting', $owner));
 
         // in reverse order
-        $settingsManager->set('some_setting', 'VALUE_USER_2', $user);
+        $settingsManager->set('some_setting', 'VALUE_USER_2', $owner);
         $settingsManager->set('some_setting', 'VALUE_GLOBAL_2');
         $this->assertEquals('VALUE_GLOBAL_2', $settingsManager->get('some_setting'));
-        $this->assertEquals('VALUE_USER_2', $settingsManager->get('some_setting', $user));
+        $this->assertEquals('VALUE_USER_2', $settingsManager->get('some_setting', $owner));
     }
 
     public function testUsersSettingsArentIntersect()
     {
-        $user1 = $this->createUser(1);
-        $user2 = $this->createUser(2);
+        $owner1 = $this->createOwner(1);
+        $owner2 = $this->createOwner(2);
         $settingsManager = $this->createSettingsManager();
-        $settingsManager->set('some_setting', 'VALUE_USER_1', $user1);
-        $settingsManager->set('some_setting', 'VALUE_USER_2', $user2);
-        $this->assertEquals('VALUE_USER_1', $settingsManager->get('some_setting', $user1));
-        $this->assertEquals('VALUE_USER_2', $settingsManager->get('some_setting', $user2));
+        $settingsManager->set('some_setting', 'VALUE_USER_1', $owner1);
+        $settingsManager->set('some_setting', 'VALUE_USER_2', $owner2);
+        $this->assertEquals('VALUE_USER_1', $settingsManager->get('some_setting', $owner1));
+        $this->assertEquals('VALUE_USER_2', $settingsManager->get('some_setting', $owner2));
 
         // in reverse order
-        $settingsManager->set('some_setting', 'VALUE_USER_2', $user2);
-        $settingsManager->set('some_setting', 'VALUE_USER_1', $user1);
-        $this->assertEquals('VALUE_USER_1', $settingsManager->get('some_setting', $user1));
-        $this->assertEquals('VALUE_USER_2', $settingsManager->get('some_setting', $user2));
+        $settingsManager->set('some_setting', 'VALUE_USER_2', $owner2);
+        $settingsManager->set('some_setting', 'VALUE_USER_1', $owner1);
+        $this->assertEquals('VALUE_USER_1', $settingsManager->get('some_setting', $owner1));
+        $this->assertEquals('VALUE_USER_2', $settingsManager->get('some_setting', $owner2));
     }
 
     public function testPersistence()
@@ -112,12 +112,12 @@ class SettingsManagerTest extends AbstractTest
      */
     public function testSetUserSettingInGlobalScopeRaisesException()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
         $settingsManager->set('some_global_setting', 'VALUE_GLOBAL');
         $this->assertEquals('VALUE_GLOBAL', $settingsManager->get('some_global_setting'));
 
-        $settingsManager->set('some_global_setting', 'VALUE_GLOBAL', $user);
+        $settingsManager->set('some_global_setting', 'VALUE_GLOBAL', $owner);
     }
 
     /**
@@ -125,9 +125,9 @@ class SettingsManagerTest extends AbstractTest
      */
     public function testGetUserSettingInGlobalScopeRaisesException()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
-        $settingsManager->get('some_global_setting', $user);
+        $settingsManager->get('some_global_setting', $owner);
     }
 
     /**
@@ -135,10 +135,10 @@ class SettingsManagerTest extends AbstractTest
      */
     public function testSetGlobalSettingInUserScopeRaisesException()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
-        $settingsManager->set('some_user_setting', 'VALUE_USER', $user);
-        $this->assertEquals('VALUE_USER', $settingsManager->get('some_global_setting', $user));
+        $settingsManager->set('some_user_setting', 'VALUE_USER', $owner);
+        $this->assertEquals('VALUE_USER', $settingsManager->get('some_global_setting', $owner));
 
         $settingsManager->set('some_user_setting', 'VALUE_USER');
     }
@@ -160,24 +160,24 @@ class SettingsManagerTest extends AbstractTest
 
     public function testGetAllUserSettings()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
-        $this->assertEquals(array('some_setting' => null, 'some_setting2' => null, 'some_user_setting' => null), $settingsManager->all($user));
+        $this->assertEquals(array('some_setting' => null, 'some_setting2' => null, 'some_user_setting' => null), $settingsManager->all($owner));
     }
 
     public function testScopeAll()
     {
-        $user = $this->createUser();
+        $owner = $this->createOwner();
         $settingsManager = $this->createSettingsManager();
 
         // Global settings should be shown if there is no user setting defined
         $settingsManager->set('some_setting', 'value');
         $this->assertEquals('value', $settingsManager->get('some_setting'));
-        $this->assertEquals('value', $settingsManager->get('some_setting', $user), 'Did not get global value when local value was undefined.');
+        $this->assertEquals('value', $settingsManager->get('some_setting', $owner), 'Did not get global value when local value was undefined.');
 
         // The users settings should always be prioritised over the global one (if it exists)
-        $settingsManager->set('some_setting', 'user_value', $user);
-        $this->assertEquals('user_value', $settingsManager->get('some_setting', $user), 'User/Local value should have priority over global.');
+        $settingsManager->set('some_setting', 'user_value', $owner);
+        $this->assertEquals('user_value', $settingsManager->get('some_setting', $owner), 'User/Local value should have priority over global.');
         $this->assertEquals('value', $settingsManager->get('some_setting'));
     }
 
@@ -216,9 +216,9 @@ class SettingsManagerTest extends AbstractTest
     /**
      * @param string $ownerId
      *
-*@return \Dmishh\Bundle\SettingsBundle\Entity\SettingOwner
+     * @return \Dmishh\Bundle\SettingsBundle\Entity\SettingOwner
      */
-    protected function createUser($ownerId = 'user1')
+    protected function createOwner($ownerId = 'user1')
     {
         return Mockery::mock('Dmishh\Bundle\SettingsBundle\Entity\SettingOwner', array('getSettingIdentifier' => $ownerId));
     }

--- a/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
@@ -198,11 +198,11 @@ class SettingsManagerTest extends AbstractTest
 
     /**
      * @param string $username
-     * @return \Symfony\Component\Security\Core\User\UserInterface
+     * @return \Dmishh\Bundle\SettingsBundle\Entity\SettingOwner
      */
     protected function createUser($username = 'user1')
     {
-        return Mockery::mock('Symfony\Component\Security\Core\User\UserInterface', array('getUsername' => $username));
+        return Mockery::mock('Dmishh\Bundle\SettingsBundle\Entity\SettingOwner', array('getUsername' => $username));
     }
 
     protected function createSettingsManager(array $configuration = array(), $serialization = 'php')

--- a/src/Dmishh/Bundle/SettingsBundle/Twig/SettingsExtension.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Twig/SettingsExtension.php
@@ -12,7 +12,7 @@
 namespace Dmishh\Bundle\SettingsBundle\Twig;
 
 use Dmishh\Bundle\SettingsBundle\Manager\SettingsManagerInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Dmishh\Bundle\SettingsBundle\Entity\SettingOwner;
 
 /**
  * Extension for retreiving settings in Twig templates
@@ -43,10 +43,10 @@ class SettingsExtension extends \Twig_Extension
      * Proxy to SettingsManager::get
      *
      * @param string $name
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return mixed
      */
-    public function getSetting($name, UserInterface $user = null)
+    public function getSetting($name, SettingOwner $user = null)
     {
         return $this->settingsManager->get($name, $user);
     }
@@ -54,10 +54,10 @@ class SettingsExtension extends \Twig_Extension
     /**
      * Proxy to SettingsManager::all
      *
-     * @param UserInterface|null $user
+     * @param SettingOwner|null $user
      * @return array
      */
-    public function getAllSettings(UserInterface $user = null)
+    public function getAllSettings(SettingOwner $user = null)
     {
         return $this->settingsManager->all($user);
     }

--- a/src/Dmishh/Bundle/SettingsBundle/Twig/SettingsExtension.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Twig/SettingsExtension.php
@@ -43,23 +43,25 @@ class SettingsExtension extends \Twig_Extension
      * Proxy to SettingsManager::get
      *
      * @param string $name
-     * @param SettingOwner|null $user
-     * @return mixed
+     * @param SettingOwner|null $owner
+     *
+*@return mixed
      */
-    public function getSetting($name, SettingOwner $user = null)
+    public function getSetting($name, SettingOwner $owner = null)
     {
-        return $this->settingsManager->get($name, $user);
+        return $this->settingsManager->get($name, $owner);
     }
 
     /**
      * Proxy to SettingsManager::all
      *
-     * @param SettingOwner|null $user
-     * @return array
+     * @param SettingOwner|null $owner
+     *
+*@return array
      */
-    public function getAllSettings(SettingOwner $user = null)
+    public function getAllSettings(SettingOwner $owner = null)
     {
-        return $this->settingsManager->all($user);
+        return $this->settingsManager->all($owner);
     }
 
     /**


### PR DESCRIPTION
We do no longer require to implement the `Symfony\Component\Security\Core\User\UserInterface`. By using our own interface we allow to have multiple "settings owners" without breaking the single responsibility principle. 

This PR will (of course) break backwards compatibility. And should force the next version to be 2.0.0. 