### PR TITLE
Removed the unused user_class config

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Full list of options:
 
 ```yaml
 dmishh_settings:
-    user_class: Dmishh/Bundle/SettingsBundle/Entity/User # change this to your user class
     layout: DmishhSettingsBundle::layout.html.twig
     template: DmishhSettingsBundle:Settings:manage.html.twig
     security:
@@ -228,13 +227,12 @@ $this->get('settings_manager')->get('user_scope_setting'); // => WrongScopeExcep
 $this->get('settings_manager')->set('user_scope_setting', 'value'); // => WrongScopeException
 ```
 
-#### Configuring per-user settings
+#### Configuring scope
 
-To use this feature, ```user_class``` option must be defined. Then you can set GLOBAL or USER scope for your settings.
+You may configure a scope to each of your settings. You can use ALL (default), GLOBAL or USER scope.
 
 ```yaml
 dmishh_settings:
-    user_class: Dmishh/Bundle/SettingsBundle/Entity/User # change this to your user class
     settings:
         my_first_user_setting:
             scope: user # or "all" if you want for that setting to be visible as global setting

--- a/src/Dmishh/Bundle/SettingsBundle/DependencyInjection/Configuration.php
+++ b/src/Dmishh/Bundle/SettingsBundle/DependencyInjection/Configuration.php
@@ -34,8 +34,6 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('user_class')
-                ->end()
                 ->scalarNode('layout')
                     ->defaultValue('DmishhSettingsBundle::layout.html.twig')
                 ->end()


### PR DESCRIPTION
The [Readme says](https://github.com/dmishh/SettingsBundle/blob/master/README.md#configuring-per-user-settings) we need to specify the user class in the config. But why? We are never using that value, are we?

This PR removes that config value. 