### PR TITLE
Using a factory service to create the serializer service

### DIFF
--- a/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
@@ -60,14 +60,14 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * @param ObjectManager $em
      * @param array $settingsConfiguration
-     * @param string $serialization
+     * @param SerializerInterface $serializer
      */
-    public function __construct(ObjectManager $em, array $settingsConfiguration = array(), $serialization = 'php')
+    public function __construct(ObjectManager $em, array $settingsConfiguration = array(), SerializerInterface $serializer)
     {
         $this->em = $em;
         $this->repository = $em->getRepository('Dmishh\\Bundle\\SettingsBundle\\Entity\\Setting');
         $this->settingsConfiguration = $settingsConfiguration;
-        $this->serializer = SerializerFactory::create($serialization);
+        $this->serializer = $serializer;
     }
 
     /**

--- a/src/Dmishh/Bundle/SettingsBundle/Resources/config/services.yml
+++ b/src/Dmishh/Bundle/SettingsBundle/Resources/config/services.yml
@@ -4,7 +4,16 @@ services:
         arguments:
             - @doctrine.orm.entity_manager
             - %settings_manager.settings%
-            - %settings_manager.serialization%
+            - @dmishh.settings.serializer
+
+    dmishh.settings.serializer_factory:
+        class: Dmishh\Bundle\SettingsBundle\Serializer\SerializerFactory
+
+    dmishh.settings.serializer:
+        class: Dmishh\Bundle\SettingsBundle\Serializer\SerializerInterface
+        factory_service: dmishh.settings.serializer_factory
+        factory_method: create
+        arguments: [%settings_manager.serialization%]
 
     form.type.settings_management:
         class: Dmishh\Bundle\SettingsBundle\Form\Type\SettingsType

--- a/src/Dmishh/Bundle/SettingsBundle/Serializer/SerializerFactory.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Serializer/SerializerFactory.php
@@ -14,7 +14,7 @@ namespace Dmishh\Bundle\SettingsBundle\Serializer;
 use Dmishh\Bundle\SettingsBundle\Exception\UnknownSerializerException;
 use Symfony\Component\DependencyInjection\Container;
 
-abstract class SerializerFactory
+class SerializerFactory
 {
     /**
      * @param string $name short name of serializer (ex.: php) or full class name

--- a/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
@@ -13,6 +13,7 @@ namespace Dmishh\Bundle\SettingsBundle\Tests;
 
 use Dmishh\Bundle\SettingsBundle\Manager\SettingsManager;
 use Dmishh\Bundle\SettingsBundle\Manager\SettingsManagerInterface;
+use Dmishh\Bundle\SettingsBundle\Serializer\SerializerFactory;
 use Mockery;
 
 class SettingsManagerTest extends AbstractTest
@@ -216,6 +217,7 @@ class SettingsManagerTest extends AbstractTest
             );
         }
 
-        return new SettingsManager($this->em, $configuration, $serialization);
+        $serializer = SerializerFactory::create($serialization);
+        return new SettingsManager($this->em, $configuration, $serializer);
     }
 }


### PR DESCRIPTION
When you create the serializer object from the constructor you introduce very tight coupling between the SettingsManager and the serializer. A user may not use his own serializer without extending the SettingsManager and override the `__construct()`

By injecting the a serializer service we solve this problem. 