### PR TITLE
Make sure that we fetch global setting if user setting does not exist

### DIFF
--- a/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Manager/SettingsManager.php
@@ -80,12 +80,20 @@ class SettingsManager implements SettingsManagerInterface
 
         $value = null;
 
-        if ($user === null) {
-            $value = $this->globalSettings[$name];
-        } else {
-            if ($this->userSettings[$user->getUsername()][$name] !== null) {
-                $value = $this->userSettings[$user->getUsername()][$name];
-            }
+        switch ($this->settingsConfiguration[$name]['scope']) {
+            case SettingsManagerInterface::SCOPE_GLOBAL:
+                $value = $this->globalSettings[$name];
+                break;
+            case SettingsManagerInterface::SCOPE_ALL:
+                $value = $this->globalSettings[$name];
+                //Do not break here. Try to fetch the users settings
+            case SettingsManagerInterface::SCOPE_USER:
+                if ($user !== null) {
+                    if ($this->userSettings[$user->getUsername()][$name] !== null) {
+                        $value = $this->userSettings[$user->getUsername()][$name];
+                    }
+                }
+                break;
         }
 
         return $value;

--- a/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Tests/SettingsManagerTest.php
@@ -165,6 +165,22 @@ class SettingsManagerTest extends AbstractTest
         $this->assertEquals(array('some_setting' => null, 'some_setting2' => null, 'some_user_setting' => null), $settingsManager->all($user));
     }
 
+    public function testScopeAll()
+    {
+        $user = $this->createUser();
+        $settingsManager = $this->createSettingsManager();
+
+        // Global settings should be shown if there is no user setting defined
+        $settingsManager->set('some_setting', 'value');
+        $this->assertEquals('value', $settingsManager->get('some_setting'));
+        $this->assertEquals('value', $settingsManager->get('some_setting', $user), 'Did not get global value when local value was undefined.');
+
+        // The users settings should always be prioritised over the global one (if it exists)
+        $settingsManager->set('some_setting', 'user_value', $user);
+        $this->assertEquals('user_value', $settingsManager->get('some_setting', $user), 'User/Local value should have priority over global.');
+        $this->assertEquals('value', $settingsManager->get('some_setting'));
+    }
+
     public function testValidSerizalizationTypes()
     {
         $settingsManager = $this->createSettingsManager(array(), 'php');


### PR DESCRIPTION
From the readme:

``` php
// Example with ALL scope
$this->get('settings_manager')->set('all_scope_setting', 'value');
$this->get('settings_manager')->get('all_scope_setting'); // => 'value'
$this->get('settings_manager')->get('all_scope_setting', $this->getUser()); // => 'value'
$this->get('settings_manager')->set('all_scope_setting', 'user_value', $this->getUser());
$this->get('settings_manager')->get('all_scope_setting', $this->getUser()); // => 'user_value'
```

This does not work. When you running `$this->get('settings_manager')->get('all_scope_setting', $this->getUser()); // => 'value'` you will get null back. 

This PR adds a test for this use case and also a fix.