### PR TITLE
Make sure we dont store too much data in the container

### DIFF
--- a/src/Dmishh/Bundle/SettingsBundle/DependencyInjection/DmishhSettingsExtension.php
+++ b/src/Dmishh/Bundle/SettingsBundle/DependencyInjection/DmishhSettingsExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
@@ -33,11 +33,12 @@ class DmishhSettingsExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        foreach ($config as $key => $value) {
-            $container->setParameter('settings_manager.' . $key, $value);
+        $globalSettings = ['template', 'security', 'layout'];
+        foreach ($globalSettings as $key) {
+            $container->setParameter('settings_manager.'.$key, $config[$key]);
         }
 
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
         // Configure the correct storage
@@ -51,5 +52,8 @@ class DmishhSettingsExtension extends Extension
         }
 
         $container->setParameter('dmishh.settings.cache.lifetime', $config['cache_lifetime']);
+        $container->findDefinition('dmishh.settings.settings_manager')->replaceArgument(2, $config['settings']);
+        $container->findDefinition('form.type.settings_management')->replaceArgument(0, $config['settings']);
+        $container->findDefinition('dmishh.settings.serializer')->replaceArgument(0, $config['serialization']);
     }
 }

--- a/src/Dmishh/Bundle/SettingsBundle/Resources/config/services.yml
+++ b/src/Dmishh/Bundle/SettingsBundle/Resources/config/services.yml
@@ -7,7 +7,7 @@ services:
         arguments:
             - @doctrine.orm.entity_manager
             - @dmishh.settings.serializer
-            - %settings_manager.settings%
+            - ~
 
     dmishh.settings.cached_settings_manager:
         class: Dmishh\Bundle\SettingsBundle\Manager\CachedSettingsManager
@@ -20,12 +20,11 @@ services:
         class: Dmishh\Bundle\SettingsBundle\Serializer\SerializerInterface
         factory_service: dmishh.settings.serializer_factory
         factory_method: create
-        arguments: [%settings_manager.serialization%]
+        arguments: [~]
 
     form.type.settings_management:
         class: Dmishh\Bundle\SettingsBundle\Form\Type\SettingsType
-        arguments:
-            - %settings_manager.settings%
+        arguments: [~]
         tags:
             - { name: form.type, alias: settings_management }
 


### PR DESCRIPTION
Since the array with settings could be quite large we don't need to have it in memory on every request. 

This PR makes sure to inject such data into the services that needs it. This is a BC break, but it is okey for 2.0. 