### PR TITLE
Improved the error message for WrongScopeException

### DIFF
--- a/src/Dmishh/Bundle/SettingsBundle/Exception/WrongScopeException.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Exception/WrongScopeException.php
@@ -11,10 +11,20 @@
 
 namespace Dmishh\Bundle\SettingsBundle\Exception;
 
+use Dmishh\Bundle\SettingsBundle\Manager\SettingsManagerInterface;
+
 class WrongScopeException extends SettingsException
 {
-    public function __construct($scopeName, $settingName)
+    public function __construct($scope, $settingName)
     {
-        parent::__construct(sprintf('Wrong scope "%s" for setting "%s". Check your configuration and make sure that user is authenticated.', $scopeName, $settingName));
+        if ($scope === SettingsManagerInterface::SCOPE_GLOBAL) {
+            $message = sprintf('You tried to access setting "%s" but it is in the "%s" scope which means you must not use a SettingOwnerInterface object with this option.', $settingName, $scope);
+        } elseif ($scope === SettingsManagerInterface::SCOPE_USER) {
+            $message = sprintf('You tried to access setting "%s" but it is in the "%s" scope which means you have to pass a SettingOwnerInterface object with this option.', $settingName, $scope);
+        } else {
+            $message = sprintf('Wrong scope "%s" for setting "%s". Check your configuration.', $scope, $settingName);
+        }
+
+        parent::__construct($message);
     }
 }


### PR DESCRIPTION
This will improve the error message in the WrongScopeException. It gives the user more detailed information what they did wrong. 