### PR TITLE
Fixed column name

### DIFF
--- a/src/Dmishh/Bundle/SettingsBundle/Entity/Setting.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Entity/Setting.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(
  *  name="dmishh_settings",
- *  indexes={@ORM\Index(name="name_owner_id_idx", columns={"name", "ownerId"})}
+ *  indexes={@ORM\Index(name="name_owner_id_idx", columns={"name", "owner_id"})}
  * )
  * @ORM\Entity
  */
@@ -50,7 +50,7 @@ class Setting
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=255, nullable=true)
+     * @ORM\Column(name="owner_id", type="string", length=255, nullable=true)
      */
     private $ownerId;
 


### PR DESCRIPTION
It is possible choice a default name strategy, so it is important to name explicitly column. And the default  naming strategy in the latest Symfony standard edition is ``doctrine.orm.naming_strategy.underscore``.