### PR TITLE
SF2.7+ compatibility

### DIFF
--- a/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
@@ -25,12 +25,7 @@ class SettingsController extends Controller
     public function manageGlobalAction(Request $request)
     {
         $securitySettings = $this->container->getParameter('settings_manager.security');
-
-        if ($this->has('security.authorization_checker')) {
-            $securityContext = $this->get('security.authorization_checker');
-        } else { // SF < 2.6
-            $securityContext = $this->get('security.context');
-        }
+        $securityContext = $this->getSecurityContext('security.authorization_checker');
 
         if (!empty($securitySettings['manage_global_settings_role']) && !$securityContext->isGranted(
                 $securitySettings['manage_global_settings_role']
@@ -54,12 +49,7 @@ class SettingsController extends Controller
      */
     public function manageOwnAction(Request $request)
     {
-        if ($this->has('security.token_storage')) {
-            $securityContext = $this->get('security.token_storage');
-        } else { // SF < 2.6
-            $securityContext = $this->get('security.context');
-        }
-
+        $securityContext = $this->getSecurityContext('security.token_storage');
         if (!$securityContext->getToken()) {
             throw new AccessDeniedException($this->get('translator')->trans(
                 'must_be_logged_in_to_edit_own_settings',
@@ -119,5 +109,21 @@ class SettingsController extends Controller
                 'layout' => $this->container->getParameter('settings_manager.layout'),
             )
         );
+    }
+
+    /**
+     * Get SecurityContext service
+     * @param string $service The service name
+     *
+     * @return mixed The service
+     */
+    private function getSecurityContext($service)
+    {
+        if ($this->has($service)) {
+            return $this->get($service);
+        }
+
+        // SF < 2.6
+        return $this->get('security.context');
     }
 }

--- a/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Controller/SettingsController.php
@@ -26,7 +26,7 @@ class SettingsController extends Controller
     {
         $securitySettings = $this->container->getParameter('settings_manager.security');
 
-        if (class_exists('\Symfony\Component\Security\Core\Security')) {
+        if ($this->has('security.authorization_checker')) {
             $securityContext = $this->get('security.authorization_checker');
         } else { // SF < 2.6
             $securityContext = $this->get('security.context');
@@ -54,7 +54,7 @@ class SettingsController extends Controller
      */
     public function manageOwnAction(Request $request)
     {
-        if (class_exists('\Symfony\Component\Security\Core\Security')) {
+        if ($this->has('security.token_storage')) {
             $securityContext = $this->get('security.token_storage');
         } else { // SF < 2.6
             $securityContext = $this->get('security.context');

--- a/src/Dmishh/Bundle/SettingsBundle/Form/Type/SettingsType.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Form/Type/SettingsType.php
@@ -14,6 +14,7 @@ namespace Dmishh\Bundle\SettingsBundle\Form\Type;
 use Dmishh\Bundle\SettingsBundle\Exception\SettingsException;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -75,9 +76,20 @@ class SettingsType extends AbstractType
     }
 
     /**
+     * SF < 2.7
      * {@inheritDoc}
+     * @deprecated since version 2.3, to be renamed in 3.0.
+     *             Use the method configureSettings instead
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -85,12 +97,17 @@ class SettingsType extends AbstractType
             )
         );
 
-        $resolver->addAllowedTypes(
-            array(
-                'disabled_settings' => 'array'
-            )
-        );
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->addAllowedTypes('disabled_settings', 'array');
+        } else {
+            $resolver->addAllowedTypes(
+                array(
+                    'disabled_settings' => 'array'
+                )
+            );
+        }
     }
+
 
     /**
      * {@inheritDoc}

--- a/src/Dmishh/Bundle/SettingsBundle/Form/Type/SettingsType.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Form/Type/SettingsType.php
@@ -97,6 +97,8 @@ class SettingsType extends AbstractType
             )
         );
 
+        // SF2.6 : parameters of OptionsResolver::addAllowedTypes change and OptionsResolver::setDefined was include
+        // @see https://github.com/symfony/OptionsResolver/blob/master/CHANGELOG.md#260 
         if (method_exists($resolver, 'setDefined')) {
             $resolver->addAllowedTypes('disabled_settings', 'array');
         } else {

--- a/src/Dmishh/Bundle/SettingsBundle/Form/Type/SettingsType.php
+++ b/src/Dmishh/Bundle/SettingsBundle/Form/Type/SettingsType.php
@@ -108,7 +108,6 @@ class SettingsType extends AbstractType
         }
     }
 
-
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Hi,

This PR remove deprecated warning with SF >= 2.7.
"security.context" service will be remove in SF 3.0

I keep methods to be compatibility with SF <= 2.6.