### PR TITLE
template renaming, remove `layout` parameter

### DIFF
--- a/Controller/SettingsController.php
+++ b/Controller/SettingsController.php
@@ -105,7 +105,6 @@ class SettingsController extends Controller
             $this->container->getParameter('settings_manager.template'),
             array(
                 'settings_form' => $form->createView(),
-                'layout' => $this->container->getParameter('settings_manager.layout'),
             )
         );
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,9 +34,6 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('layout')
-                    ->defaultValue('DmishhSettingsBundle::layout.html.twig')
-                ->end()
                 ->scalarNode('template')
                     ->defaultValue('DmishhSettingsBundle:Settings:manage.html.twig')
                 ->end()

--- a/Resources/doc/advanced-configuration.md
+++ b/Resources/doc/advanced-configuration.md
@@ -14,7 +14,6 @@ Full list of options:
 
 ```yaml
 dmishh_settings:
-    layout: DmishhSettingsBundle::layout.html.twig
     template: DmishhSettingsBundle:Settings:manage.html.twig
     cache_service: null
     cache_lifetime: 3600

--- a/Resources/doc/customization.md
+++ b/Resources/doc/customization.md
@@ -10,28 +10,16 @@
 
 ## Customization
 
-#### Overriding layout
+#### Overriding layout via bundle inheritance
 
-##### Via config
+Make use of Symfony Bundle Inheritance to expose the bundle via your own template. See the Symfony Cookbook for an
+article about how to override parts of a bundle.
 
-Set your layout in config
-
-```yaml
-dmishh_settings:
-    layout: DmishhSettingsBundle::layout.html.twig # change to your own
-```
-
-Place ```settings_form``` block near your main content block
-
-```twig
-{% block settings_form %}{% endblock %}
-```
-
-##### Via bundle inheritance
-
-TODO
+* [How to Use Bundle Inheritance to Override Parts of a Bundle »](http://symfony.com/doc/current/cookbook/bundles/inheritance.html#overriding-resources-templates-routing-etc)
 
 #### Overriding template
+
+The template the bundle controller will use can be overwritten by changing the configuration parameter.
 
 ```yaml
 dmishh_settings:

--- a/Resources/views/Settings/manage.html.twig
+++ b/Resources/views/Settings/manage.html.twig
@@ -1,11 +1,10 @@
-{% extends layout %}
+{% extends 'DmishhSettingsBundle::layout.html.twig' %}
 
-{% block settings_form %}
+{% block content %}
     <h1>{% trans from 'settings' %}settings{% endtrans %}</h1>
 
-    <form method="post" id="settings-form" {{ form_enctype(settings_form) }}>
+    {{ form_start(settings_form) }}
         {{ form_widget(settings_form) }}
-
         <input type="submit" value="{% trans from 'settings' %}save{% endtrans %}" />
-    </form>
+    {{ form_end(settings_form) }}
 {% endblock %}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -1,23 +1,17 @@
 <!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8" />
-    <title></title>
-    {% block stylesheets %}
-        {#
-        {% stylesheets '@DmishhSettingsBundle/Resources/assets/css/form.css' %}
-        <link type="text/css" rel="stylesheet" href="{{ asset_url }}" />
-        {% endstylesheets %}
-        #}
-    {% endblock %}
-</head>
-<body>
-    {% for flashMessage in app.session.flashbag.get('error') %}
-        <div class="error">{{ flashMessage }}</div>
-    {% endfor %}
-    {% for flashMessage in app.session.flashbag.get('success') %}
-        <div class="success">{{ flashMessage }}</div>
-    {% endfor %}
-    {% block settings_form %}{% endblock %}
-</body>
+    <html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>{% block title %}{% endblock %}</title>
+        {% block stylesheets %}{% endblock %}
+    </head>
+    <body>
+        {% for flashMessage in app.session.flashbag.get('error') %}
+            <div class="message error">{{ flashMessage }}</div>
+        {% endfor %}
+        {% for flashMessage in app.session.flashbag.get('success') %}
+            <div class="message success">{{ flashMessage }}</div>
+        {% endfor %}
+        {% block content %}{% endblock %}
+    </body>
 </html>


### PR DESCRIPTION
Fixes #37 also added `message` class to flashbag messages. Make use of `{{ form_start() }}` and `{{ form_end() }}` to render the form.