### PR TITLE
Require `symfony/form` and fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
 
 install:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+  - composer require symfony/form:${SYMFONY_VERSION} --no-update
   - composer update
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+## Changelog
+
+#### Version 2.0.0-dev
+
+* Added optional caching
+* New interface for your entity. We are no longer using `UserInterface`. Use `SettingsOwnerInterface` instead.
+* Changed behavior of `SettingsManager::all`. It will not return global config if the user/local values are missing
+* Added possibility to add default value as third parameter on `SettingsManager::get`
+* Updated namespace to `Dmishh\SettingsBundle` instead of `Dmishh\Bundle\SettingsBundle`
+* Updated the configuration. This break BC but makes sure the configuration is not as "deep". [#31](https://github.com/dmishh/SettingsBundle/issues/31)
+* Bump PHP to `^5.5.9` and Symfony to `^2.7|^3.0` [#50](https://github.com/dmishh/SettingsBundle/issues/50)
+
+#### Version 1.0.2-1.0.7 (9 Mar 2015)
+* Minor code improvements and bug fixes
+* System messages translations to en, it, es, fr, de, ru, uk, sv languages
+
+#### Version 1.0.1 (13 May 2014)
+* Ability to choose serialization mechanism (php or json)
+* Ability to add constraints to validation
+
+#### Version 1.0.0 (3 Apr 2014)
+* First stable version

--- a/Form/Type/SettingsType.php
+++ b/Form/Type/SettingsType.php
@@ -15,7 +15,6 @@ use Dmishh\SettingsBundle\Exception\SettingsException;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Settings management form.
@@ -77,18 +76,6 @@ class SettingsType extends AbstractType
     }
 
     /**
-     * SF < 2.7
-     * {@inheritdoc}
-     *
-     * @deprecated since version 2.3, to be renamed in 3.0.
-     *             Use the method configureSettings instead
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
@@ -98,24 +85,12 @@ class SettingsType extends AbstractType
                 'disabled_settings' => array(),
             )
         );
-
-        // SF 2.6 : parameters of OptionsResolver::addAllowedTypes change and OptionsResolver::setDefined was include
-        // @see https://github.com/symfony/OptionsResolver/blob/master/CHANGELOG.md#260
-        if (method_exists($resolver, 'setDefined')) {
-            $resolver->addAllowedTypes('disabled_settings', 'array');
-        } else {
-            $resolver->addAllowedTypes(
-                array(
-                    'disabled_settings' => 'array',
-                )
-            );
-        }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'settings_management';
     }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SettingsBundle
 ==============
 
-Bundle is used for storing configuration with Symfony2 in database using Doctrine2 ORM.
+Bundle for storing configuration with Symfony in database using Doctrine2 ORM.
 
 [![Build Status](https://travis-ci.org/dmishh/SettingsBundle.png?branch=master)](https://travis-ci.org/dmishh/SettingsBundle)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/5375684f-5b40-489a-aca5-eb01c3ca5ac2/small.png)](https://insight.sensiolabs.com/projects/5375684f-5b40-489a-aca5-eb01c3ca5ac2)
@@ -9,11 +9,11 @@ Bundle is used for storing configuration with Symfony2 in database using Doctrin
 ## Features
 
 * Easy-to-use (Twig extension, container service)
-* Fast and extensible
 * Settings scopes per user, global or all
-* Settings validation using full power of Symfony2 Form Component
-* 2 serialization mechanisms in DB: PHP's native `serialize()` and JSON + you can write your own
-* Settings caching
+* Settings validation by using the Symfony Form Component
+* 2 serialization mechanisms: PHP `serialize()` and JSON (+ you can write your own)
+* Settings caching (PSR-6)
+* Fast and extensible
 
 ## Quick usage examples
 
@@ -52,31 +52,13 @@ See the [general usage](/Resources/doc/general-usage.md) documentation for more 
 * [Customization](/Resources/doc/customization.md)
 * [FAQ](/Resources/doc/faq.md)
 
-## Roadmap and contribution
+## Changelog, Roadmap and contribution
 
 Please, do not hesitate to [report bugs](https://github.com/dmishh/SettingsBundle/issues) or send
 [pull requests](https://github.com/dmishh/SettingsBundle/pulls). It will help to motivate me to support
 library better than anything else :)
 
-#### Version 2.0.0-dev
-
-* Added optional caching
-* New interface for your entity. We are no longer using `UserInterface`. Use `SettingsOwnerInterface` instead.
-* Changed behavior of `SettingsManager::all`. It will not return global config if the user/local values are missing
-* Added possibility to add default value as third parameter on `SettingsManager::get`
-* Updated namespace to `Dmishh\SettingsBundle` instead of `Dmishh\Bundle\SettingsBundle`
-* Updated the configuration. This break BC but makes sure the configuration is not as "deep". [#31](https://github.com/dmishh/SettingsBundle/issues/31)
-
-#### Version 1.0.2-1.0.7
-* Minor code improvements and bug fixes
-* System messages translations to en, it, es, fr, de, ru, uk, sv languages
-
-#### Version 1.0.1
-* Ability to choose serialization mechanism (php or json)
-* Ability to add constraints to validation
-
-#### Version 1.0.0
-* First stable version
+See [CHANGELOG.md](CHANGELOG.md) for all major changes.
 
 ### Upgrade from 1.0.*
 
@@ -85,5 +67,3 @@ Make sure to read the [UPGRADE.md](UPGRADE.md) to successfully migrate your appl
 ## License
 
 The MIT License. For the full text of license, please, see [LICENSE](/LICENSE)
-
-© 2013-2015 [Dmitriy Scherbina](http://dmishh.com)

--- a/Resources/doc/advanced-configuration.md
+++ b/Resources/doc/advanced-configuration.md
@@ -23,7 +23,7 @@ dmishh_settings:
     serialization: php # database serialization mechanism (php|json)
     settings:
         my_first_setting:
-            type: number # any Symfony2 form type
+            type: number # any Symfony form type
             options: # options passed to form
                 required: false
             constraints:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dmishh/settings-bundle",
-    "description": "Database centric Symfony2 configuration management. Global and per-user settings supported. It just works.",
-    "keywords": ["symfony2", "bundle", "config", "configuration", "settings"],
+    "description": "Database centric Symfony configuration management. Global and per-user settings supported.",
+    "keywords": ["symfony", "bundle", "config", "configuration", "settings"],
     "homepage": "https://github.com/dmishh/SettingsBundle",
     "type": "symfony-bundle",
     "license": "MIT",
@@ -22,7 +22,8 @@
     "require": {
         "php": "^5.5.9|^7.0",
         "psr/cache": "^1.0",
-        "symfony/framework-bundle": "^2.3|^3.0",
+        "symfony/framework-bundle": "^2.7|^3.0",
+        "symfony/form": "^2.7|^3.0",
         "doctrine/orm": "^2.2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Fixes #73

This also bumps Symfony to `^2.7|^3.0`, as we spoke about earlier.