### PR TITLE
Make cache prefix PSR-6 compatible

### DIFF
--- a/Manager/CachedSettingsManager.php
+++ b/Manager/CachedSettingsManager.php
@@ -17,7 +17,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class CachedSettingsManager implements SettingsManagerInterface
 {
-    const PREFIX = 'dmishh_settings_o{%s}_k{%s}';
+    const PREFIX = 'dmishh_settings_%s_%s';
 
     /**
      * @var CacheItemPoolInterface


### PR DESCRIPTION
fixes #79 by removing the reserved characters from the cache key.

@Nyholm please merge and release `2.0.0-beta3` if you like.