### PR TITLE
Add note regarding form type names in Symfony 3

### DIFF
--- a/Resources/doc/advanced-configuration.md
+++ b/Resources/doc/advanced-configuration.md
@@ -23,7 +23,7 @@ dmishh_settings:
     serialization: php # database serialization mechanism (php|json)
     settings:
         my_first_setting:
-            type: number # any Symfony form type
+            type: number # any Symfony form type, or FQCN for Symfony >=3.0
             options: # options passed to form
                 required: false
             constraints:
@@ -31,6 +31,8 @@ dmishh_settings:
                     min: 1
                     max: 65535
 ```
+
+*Note:* In Symfony 3, use the fully qualified class name instead of the form type name. 
 
 
 #### Settings validation
@@ -84,16 +86,4 @@ cache_adapter:
 ```
 
 Read more about how you configure the cache adapter bundle on [www.php-cache.com](http://www.php-cache.com).
-
-### Symfony 3
-
-Because type names were [deprecated in Symfony 2.8](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form) and removed in Symfony 3.0, the type option expects the fully qualified class name instead.
-
-```yaml
-# app/config/config.yml
-dmishh_settings:
-    settings:
-        my_first_setting:
-             type: Symfony\Component\Form\Extension\Core\Type\NumberType # any Symfony form type
-```
 

--- a/Resources/doc/advanced-configuration.md
+++ b/Resources/doc/advanced-configuration.md
@@ -84,3 +84,16 @@ cache_adapter:
 ```
 
 Read more about how you configure the cache adapter bundle on [www.php-cache.com](http://www.php-cache.com).
+
+### Symfony 3
+
+Because type names were [deprecated in Symfony 2.8](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form) and removed in Symfony 3.0, the type option expects the fully qualified class name instead.
+
+```yaml
+# app/config/config.yml
+dmishh_settings:
+    settings:
+        my_first_setting:
+             type: Symfony\Component\Form\Extension\Core\Type\NumberType # any Symfony form type
+```
+

--- a/Resources/doc/advanced-configuration.md
+++ b/Resources/doc/advanced-configuration.md
@@ -32,7 +32,7 @@ dmishh_settings:
                     max: 65535
 ```
 
-*Note:* In Symfony 3, use the fully qualified class name instead of the form type name. 
+**Note:** In Symfony 3, use the fully qualified class name instead of the form type name. 
 
 
 #### Settings validation

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -73,15 +73,5 @@
 
 * Open <a href="http://YOUR-PROJECT-URL/app_dev.php/settings/global">http://YOUR-PROJECT-URL/app_dev.php/settings/global</a> and start managing your settings!
 
-### Symfony 3
-
-Because type names were [deprecated in Symfony 2.8](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form) and removed in Symfony 3.0, the default set up is slightly different.
-
-```yaml
-# app/config/config.yml
-dmishh_settings:
-    settings:
-        my_first_setting:
-            type: Symfony\Component\Form\Extension\Core\Type\TextType
-```
+*Note:* If you're using Symfony 3, please see the instructions in [Advanced configuration](advanced-configuration.md).
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -73,5 +73,5 @@
 
 * Open <a href="http://YOUR-PROJECT-URL/app_dev.php/settings/global">http://YOUR-PROJECT-URL/app_dev.php/settings/global</a> and start managing your settings!
 
-*Note:* If you're using Symfony 3, please see the instructions in [Advanced configuration](advanced-configuration.md).
+**Note:** If you're using Symfony 3, please see the instructions in [Advanced configuration](advanced-configuration.md).
 

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -72,3 +72,16 @@
     ```
 
 * Open <a href="http://YOUR-PROJECT-URL/app_dev.php/settings/global">http://YOUR-PROJECT-URL/app_dev.php/settings/global</a> and start managing your settings!
+
+### Symfony 3
+
+Because type names were [deprecated in Symfony 2.8](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form) and removed in Symfony 3.0, the default set up is slightly different.
+
+```yaml
+# app/config/config.yml
+dmishh_settings:
+    settings:
+        my_first_setting:
+            type: Symfony\Component\Form\Extension\Core\Type\TextType
+```
+


### PR DESCRIPTION
When using your bundle with the minimal configuration from your docs in Symfony 3, it fails with:

`InvalidArgumentException: Could not load type "text"`

Configuration:

```yaml
dmishh_settings:
    settings:
        my_first_setting: ~
```

This is because form type names were [deprecated in Symfony 2.8](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form) and removed in Symfony 3.0.