### PR TITLE
Initial FormType Symfony3 compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,7 +61,7 @@ class Configuration implements ConfigurationInterface
                                     ->thenInvalid('Invalid scope %s. Valid scopes are: '.implode(', ', array_map(function ($s) { return '"'.$s.'"'; }, $scopes)).'.')
                                 ->end()
                             ->end()
-                            ->scalarNode('type')->defaultValue('text')->end()
+                            ->scalarNode('type')->defaultValue('Symfony\Component\Form\Extension\Core\Type\TextType')->end()
 
                             ->variableNode('options')
                                 ->info('The options given to the form builder')


### PR DESCRIPTION
For Symfony 3 compatibility, default form type need to be "Symfony\Component\Form\Extension\Core\Type\TextType". "text" value is deprecated since Symfony 2.8 and not supported since Symfony 3.0