### PR TITLE
Ensure long running PHP processes are notified of setting changes

### DIFF
--- a/Manager/CachedSettingsManager.php
+++ b/Manager/CachedSettingsManager.php
@@ -53,6 +53,7 @@ class CachedSettingsManager implements SettingsManagerInterface
             return $cached;
         }
 
+        $this->settingsManager->clearSettings($owner);
         $value = $this->settingsManager->get($name, $owner, $default);
         $this->storeInCache($name, $value, $owner);
 

--- a/Manager/CachedSettingsManager.php
+++ b/Manager/CachedSettingsManager.php
@@ -69,6 +69,7 @@ class CachedSettingsManager implements SettingsManagerInterface
             return $cached;
         }
 
+        $this->settingsManager->clearSettings($owner);
         $value = $this->settingsManager->all($owner);
         $this->storeInCache(null, $value, $owner);
 

--- a/Manager/SettingsManager.php
+++ b/Manager/SettingsManager.php
@@ -298,7 +298,27 @@ class SettingsManager implements SettingsManagerInterface
 
         return $this;
     }
+    
+    /* 
+     * Clear locally stored settings
+     * 
+     * @param SettingsOwnerInterface|null $owner
+     *
+     * @return SettingsManager
+     */
+    public function clearSettings(SettingsOwnerInterface $owner = null)
+    {
+        if ($owner === null) {
+            $this->globalSettings = null;
+        }
 
+         if ($owner !== null && array_key_exists($owner->getSettingIdentifier(),
+                    $this->ownerSettings)) {
+             unset($this->ownerSettings[$owner->getSettingIdentifier()]);
+        }
+        
+        return $this;
+    }
     /**
      * Retreives settings from repository.
      *


### PR DESCRIPTION
When using the cache, for example redis, long running PHP processes are made aware when a setting is saved.  This is due to the cache being invalidated on save.  However if this happens the bundle will reload the setting from the global and user settings, rather than from the DB.  This means the previous, now incorrect setting will be loaded.  

The following patch ensures that the the cache is empty then the global or user setting is removed from local storage forcing the information to be pulled from the DB, refilling the cache correctly for call other clients.  Impact is very small with a decent cache lifetime and long running processes are kept in sync.