### PR TITLE
Update outdated license years

### DIFF
--- a/Controller/SettingsController.php
+++ b/Controller/SettingsController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Controller;
 
 use Dmishh\SettingsBundle\Entity\SettingsOwnerInterface;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\DependencyInjection;
 
 use Dmishh\SettingsBundle\Manager\SettingsManagerInterface;

--- a/DependencyInjection/DmishhSettingsExtension.php
+++ b/DependencyInjection/DmishhSettingsExtension.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\DependencyInjection;
 
 use Dmishh\SettingsBundle\Controller\SettingsController;

--- a/DmishhSettingsBundle.php
+++ b/DmishhSettingsBundle.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Entity/Setting.php
+++ b/Entity/Setting.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/Entity/SettingsOwnerInterface.php
+++ b/Entity/SettingsOwnerInterface.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Entity;
 
 /**

--- a/Exception/SettingsException.php
+++ b/Exception/SettingsException.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Exception;
 
 interface SettingsException extends \Throwable

--- a/Exception/UnknownSerializerException.php
+++ b/Exception/UnknownSerializerException.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Exception;
 
 class UnknownSerializerException extends \RuntimeException implements SettingsException

--- a/Exception/UnknownSettingException.php
+++ b/Exception/UnknownSettingException.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Exception;
 
 class UnknownSettingException extends \RuntimeException implements SettingsException

--- a/Exception/WrongScopeException.php
+++ b/Exception/WrongScopeException.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Exception;
 
 use Dmishh\SettingsBundle\Manager\SettingsManagerInterface;

--- a/Form/Type/SettingsType.php
+++ b/Form/Type/SettingsType.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Form\Type;
 
 use Dmishh\SettingsBundle\Exception\SettingsException;

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2013-2015 Dmitriy Scherbina <http://dmishh.com>
+© 2013 Dmitriy Scherbina <http://dmishh.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Manager/CachedSettingsManager.php
+++ b/Manager/CachedSettingsManager.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Manager;
 
 use Dmishh\SettingsBundle\Entity\SettingsOwnerInterface;

--- a/Manager/SettingsManager.php
+++ b/Manager/SettingsManager.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Manager;
 
 use Dmishh\SettingsBundle\Entity\Setting;

--- a/Manager/SettingsManagerInterface.php
+++ b/Manager/SettingsManagerInterface.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Manager;
 
 use Dmishh\SettingsBundle\Entity\SettingsOwnerInterface;

--- a/Serializer/JsonSerializer.php
+++ b/Serializer/JsonSerializer.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Serializer;
 
 class JsonSerializer implements SerializerInterface

--- a/Serializer/PhpSerializer.php
+++ b/Serializer/PhpSerializer.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Serializer;
 
 class PhpSerializer implements SerializerInterface

--- a/Serializer/SerializerFactory.php
+++ b/Serializer/SerializerFactory.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Serializer;
 
 use Dmishh\SettingsBundle\Exception\UnknownSerializerException;

--- a/Serializer/SerializerInterface.php
+++ b/Serializer/SerializerInterface.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Serializer;
 
 interface SerializerInterface

--- a/Tests/AbstractTest.php
+++ b/Tests/AbstractTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Tests;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;

--- a/Tests/Serializer/CustomSerializer.php
+++ b/Tests/Serializer/CustomSerializer.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Tests\Serializer;
 
 use Dmishh\SettingsBundle\Serializer\SerializerInterface;

--- a/Tests/SerializerTest.php
+++ b/Tests/SerializerTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Tests;
 
 use Dmishh\SettingsBundle\Serializer\SerializerFactory;

--- a/Tests/SettingsManagerTest.php
+++ b/Tests/SettingsManagerTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- *
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Tests;
 
 use Dmishh\SettingsBundle\Manager\SettingsManager;

--- a/Twig/SettingsExtension.php
+++ b/Twig/SettingsExtension.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of the DmishhSettingsBundle package.
- * (c) 2013 Dmitriy Scherbina <http://dmishh.com>
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Dmishh\SettingsBundle\Twig;
 
 use Dmishh\SettingsBundle\Manager\SettingsManagerInterface;


### PR DESCRIPTION
The dates on the license notes were outdated. We should prevent having the yearly "happy new year" commit.

The `LICENSE` file is the go-to place to find out this bundle is MIT licensed, and copyright belongs to dmishh since 2013.