### PR TITLE
Fix controller PHPStan errors 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Static code analysis
 
-on: [push]
+on: [pull_request]
 
 jobs:
   static-code-analysis:

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "nyholm/symfony-bundle-test": "^1.6",
         "symfony/translation": "^4.4 || ^5.0",
+        "symfony/security-core": "^4.4 || ^5.0",
         "twig/twig": "^2.0 || ^3.0"
     },
     "autoload": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,23 +1,8 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^PHPDoc tag @throws with type Symfony\\\\Component\\\\Security\\\\Core\\\\Exception\\\\AccessDeniedException is not subtype of Throwable$#"
-			count: 2
-			path: Controller/SettingsController.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:isGranted\\(\\)\\.$#"
 			count: 1
-			path: Controller/SettingsController.php
-
-		-
-			message: "#^Instantiated class Symfony\\\\Component\\\\Security\\\\Core\\\\Exception\\\\AccessDeniedException not found\\.$#"
-			count: 4
-			path: Controller/SettingsController.php
-
-		-
-			message: "#^Throwing object of an unknown class Symfony\\\\Component\\\\Security\\\\Core\\\\Exception\\\\AccessDeniedException\\.$#"
-			count: 4
 			path: Controller/SettingsController.php
 
 		-


### PR DESCRIPTION
because `symfony/security-core` was missing as dev dependency.