### PR TITLE
Fix deprecations

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {

--- a/Form/Type/SettingsType.php
+++ b/Form/Type/SettingsType.php
@@ -77,6 +77,9 @@ class SettingsType extends AbstractType
         );
     }
 
+    /**
+    * @return string
+    */
     public function getBlockPrefix()
     {
         return 'settings_management';

--- a/Form/Type/SettingsType.php
+++ b/Form/Type/SettingsType.php
@@ -78,8 +78,8 @@ class SettingsType extends AbstractType
     }
 
     /**
-    * @return string
-    */
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'settings_management';


### PR DESCRIPTION
Don't know if you want to provide native return types, but these changes should remove deprecation warnings to prepare the bundle for symfony 6.